### PR TITLE
Improve User views in admin

### DIFF
--- a/account/admin.py
+++ b/account/admin.py
@@ -15,7 +15,18 @@ class KATUserAdmin(UserAdmin):
     )
     fieldsets = (
         (None, {"fields": ("email", "password")}),
-        (_("Permissions"), {"fields": ("is_active", "is_staff", "is_superuser", "groups", "user_permissions")}),
+        (
+            _("Permissions"),
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                )
+            },
+        ),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
     )
     add_fieldsets = (

--- a/account/admin.py
+++ b/account/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
 
 User = get_user_model()
 
@@ -12,21 +13,17 @@ class KATUserAdmin(UserAdmin):
         "is_staff",
         "is_active",
     )
-    list_filter = (
-        "email",
-        "is_staff",
-        "is_active",
-    )
     fieldsets = (
         (None, {"fields": ("email", "password")}),
-        ("Permissions", {"fields": ("is_staff", "is_active")}),
+        (_("Permissions"), {"fields": ("is_active", "is_staff", "is_superuser", "groups", "user_permissions")}),
+        (_("Important dates"), {"fields": ("last_login", "date_joined")}),
     )
     add_fieldsets = (
         (
             None,
             {
                 "classes": ("wide",),
-                "fields": ("email", "password1", "password2", "is_staff", "is_active"),
+                "fields": ("email", "password1", "password2", "is_staff"),
             },
         ),
     )


### PR DESCRIPTION
Don't override list_filter which will remove "email" from the filter which was completely useless.

Add is_superuser, groups, user_permissions, last_login and date_joined back to the detail page.

Remove is_active from the add form.
