### PR TITLE
fix boefje settings forms for integer fields

### DIFF
--- a/katalogus/forms/plugin_settings.py
+++ b/katalogus/forms/plugin_settings.py
@@ -72,8 +72,6 @@ class PluginSettingAddEditForm(forms.Form):
                 "initial": initial,
             }
             if field["type"] == "string":
-                kwargs["max_length"] = min(
-                    MAX_SETTINGS_VALUE_LENGTH, field.get("maxLength", MAX_SETTINGS_VALUE_LENGTH)
-                )
+                kwargs["max_length"] = min(MAX_SETTINGS_VALUE_LENGTH, field.get("maxLength", MAX_SETTINGS_VALUE_LENGTH))
 
             self.fields[self.setting_name] = field_type(**kwargs)

--- a/katalogus/forms/plugin_settings.py
+++ b/katalogus/forms/plugin_settings.py
@@ -29,13 +29,17 @@ class PluginSchemaForm(forms.Form):
             field_type = FIELD_TYPES[field_props["type"]]
             if "description" in field_props:
                 help_text = field_props["description"]
-            self.fields[field_name] = field_type(
-                required=required,
-                label=field_props.get("title", field_name),
-                max_length=min(MAX_SETTINGS_VALUE_LENGTH, field_props.get("maxLength", MAX_SETTINGS_VALUE_LENGTH)),
-                help_text=_(help_text),
-                error_messages=self.error_messages,
-            )
+            kwargs = {
+                "required": required,
+                "label": field_props.get("title", field_name),
+                "help_text": _(help_text),
+                "error_messages": self.error_messages,
+            }
+            if field_props["type"] == "string":
+                kwargs["max_length"] = min(
+                    MAX_SETTINGS_VALUE_LENGTH, field_props.get("maxLength", MAX_SETTINGS_VALUE_LENGTH)
+                )
+            self.fields[field_name] = field_type(**kwargs)
 
 
 class PluginSettingAddEditForm(forms.Form):
@@ -62,11 +66,16 @@ class PluginSettingAddEditForm(forms.Form):
             initial = self.setting_value
         if field:
             field_type = FIELD_TYPES[field["type"]]
-            self.fields[self.setting_name] = field_type(
-                required=self.setting_name in self.plugin_schema["required"],
-                label=field.get("title", field),
-                max_length=min(MAX_SETTINGS_VALUE_LENGTH, field.get("maxLength", MAX_SETTINGS_VALUE_LENGTH)),
-                help_text=_(help_text),
-                error_messages=self.error_messages,
-                initial=initial,
-            )
+            kwargs = {
+                "required": self.setting_name in self.plugin_schema["required"],
+                "label": field.get("title", field),
+                "help_text": _(help_text),
+                "error_messages": self.error_messages,
+                "initial": initial,
+            }
+            if field["type"] == "string":
+                kwargs["max_length"] = min(
+                    MAX_SETTINGS_VALUE_LENGTH, field.get("maxLength", MAX_SETTINGS_VALUE_LENGTH)
+                )
+
+            self.fields[self.setting_name] = field_type(**kwargs)

--- a/katalogus/forms/plugin_settings.py
+++ b/katalogus/forms/plugin_settings.py
@@ -24,13 +24,11 @@ class PluginSchemaForm(forms.Form):
         required = False
         help_text = ""
         for field_name, field_props in fields.items():
-            if field_name in required_fields:
-                required = True
             field_type = FIELD_TYPES[field_props["type"]]
             if "description" in field_props:
                 help_text = field_props["description"]
             kwargs = {
-                "required": required,
+                "required": field_name in required_fields,
                 "label": field_props.get("title", field_name),
                 "help_text": _(help_text),
                 "error_messages": self.error_messages,


### PR DESCRIPTION
## Changes
The boefje settings form did not work for integer fields because of the max_length field.

## Proof
![image](https://user-images.githubusercontent.com/43830693/209133612-e3d2123d-b8aa-428b-92c7-6fc267f3bae7.png)

## Good to know
- Does this PR introduce or depend on API-incompatible changes? If yes: what do other users/developers need to do or confirm before merging?
  -No
- Does this PR depend on a specific version of a library?
  -No
- Does this PR require config, setup, or `.env` changes?
  -No

## Checklist for author(s):
- [x] This PR comes from a `feature` or `hotfix` branch, in line with our git branching strategy;
- [x] I have squashed all commits before merging this PR;
- [x] This PR is "bite-sized" and only focuses on a single issue, problem, or feature;
- [ ] If a non-trivial PR: This PR is properly linked to an issue on the project board;
- [ ] If a non-trivial PR: I have added screenshots or some other proof that my code does what it is supposed to do;
- [x] I am not reinventing the wheel: there is no high-quality library that already has this feature;
- [ ] I have changed the example `.env` files if I added, removed, or changed any config options, and I have informed others that they need to modify their `.env` files if required;
- [x] I have performed a self-review of my own code;
- [x] I have commented my code, particularly in hard-to-understand areas;
- [ x I have made corresponding changes to the documentation, if necessary;
- [ ] I have written unit, integration, and end-to-end tests for the change that I made;


```
## Checklist for functional reviewer(s):
- [ ] If a non-trivial PR: This PR is properly linked to an issue on the project board;
- [ ] I have checked out this branch, and successfully ran `make kat`;
- [ ] I have ran `make test-rf` and all end-to-end Robot Framework tests pass;
- [ ] I confirmed that the PR's advertised `feature` or `hotfix` works as intended;
- [ ] I confirmed that there are no unintended functional regressions in this branch;

### What works:
* _bullet point + screenshot (if useful) per tested functionality_

### What doesn't work:
* _bullet point + screenshot (if useful) per tested functionality_

### Bug or feature?:
* _bullet point + screenshot (if useful) if it is unclear whether something is a bug or an intended feature._
```

```
## Checklist for code reviewer(s):
- [ ] The code passes the CI tests and linters;
- [ ] The code does not bypass authentication or security mechanisms;
- [ ] The code does not introduce any dependency on a library that has not been properly vetted;
- [ ] The code does not violate Model-View-Template and our other architectural principles;
- [ ] The code contains docstrings, comments, and documentation where needed;
- [ ] The code prioritizes readability over performance where appropriate;
- [ ] The code conforms to our agreed coding standards.
```
