### PR TITLE
Add support for XTDB multinode

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,4 +8,6 @@ max-line-length = 120
 # E203 and W503 are recommended for compatibility with Black (https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8)
 ignore = E203, W503
 exclude = .git, __pycache__, old, build, dist, venv
-per-file-ignores = __init__.py:F401,F403
+per-file-ignores =
+    __init__.py:F401,F403
+    whitelist.py:F821

--- a/assets/src/bundles/app/css/main.scss
+++ b/assets/src/bundles/app/css/main.scss
@@ -55,9 +55,9 @@ https://sass-guidelin.es/#components-folder
 */
 @import "./components/all.scss";
 
-/* 
+/*
 6. Theme
-Branding, and visual theme layer. 
+Branding, and visual theme layer.
 */
 @import "themes/soft/manon-variables.scss"; /* Theme */
 

--- a/katalogus/client.py
+++ b/katalogus/client.py
@@ -3,19 +3,13 @@ from io import BytesIO
 from typing import Dict, Type, Set, List
 
 import requests
-from django.urls import reverse_lazy
 from octopoes.models import OOI
 from octopoes.models.types import type_by_name
 from pydantic import BaseModel
 
 from rocky.health import ServiceHealth
 from rocky.settings import KATALOGUS_API
-from tools.models import SCAN_LEVEL, Organization
-from tools.view_helpers import BreadcrumbsMixin
-
-
-class KATalogusBreadcrumbsMixin(BreadcrumbsMixin):
-    breadcrumbs = [{"text": "KAT-alogus", "url": reverse_lazy("katalogus")}]
+from tools.enums import SCAN_LEVEL
 
 
 class Plugin(BaseModel):
@@ -30,36 +24,19 @@ class Plugin(BaseModel):
     enabled: bool = True
 
 
-class KATalogusClientInterface:
-    def health(self) -> ServiceHealth:
-        raise NotImplementedError()
-
-    def get_boefjes(self) -> List[Plugin]:
-        raise NotImplementedError()
-
-    def get_boefje(self, boefje_id: str) -> Plugin:
-        raise NotImplementedError()
-
-    def enable_boefje(self, boefje_id: str) -> None:
-        raise NotImplementedError()
-
-    def disable_boefje(self, boefje_id: str) -> None:
-        raise NotImplementedError()
-
-    def get_enabled_boefjes(self) -> List[Plugin]:
-        raise NotImplementedError()
-
-    def get_description(self, boefje_id: str) -> str:
-        raise NotImplementedError()
-
-    def get_cover(self, boefje_id: str) -> BytesIO:
-        raise NotImplementedError()
-
-
-class KATalogusClientV1(KATalogusClientInterface):
+class KATalogusClientV1:
     def __init__(self, base_uri: str, organization: str):
         self.base_uri = base_uri
+        self.organization = organization
         self.organization_uri = f"{base_uri}/v1/organisations/{organization}"
+
+    def create_organization(self, name: str):
+        response = requests.post(f"{self.base_uri}/v1/organisations/", json={"id": self.organization, "name": name})
+        response.raise_for_status()
+
+    def delete_organization(self):
+        response = requests.delete(f"{self.organization_uri}")
+        response.raise_for_status()
 
     def get_all_plugins(self):
         response = requests.get(f"{self.organization_uri}/plugins")
@@ -179,9 +156,5 @@ def parse_plugin(plugin: Dict) -> Plugin:
     )
 
 
-def get_katalogus(organization: str) -> KATalogusClientInterface:
+def get_katalogus(organization: str) -> KATalogusClientV1:
     return KATalogusClientV1(KATALOGUS_API, organization)
-
-
-def get_enabled_boefjes_for_ooi_class(ooi_class: Type[OOI], organization: Organization) -> List[Plugin]:
-    return [boefje for boefje in get_katalogus(organization.code).get_enabled_boefjes() if ooi_class in boefje.consumes]

--- a/katalogus/utils.py
+++ b/katalogus/utils.py
@@ -1,0 +1,9 @@
+from typing import Type, List
+from octopoes.models import OOI
+from tools.models import Organization
+
+from katalogus.client import get_katalogus, Plugin
+
+
+def get_enabled_boefjes_for_ooi_class(ooi_class: Type[OOI], organization: Organization) -> List[Plugin]:
+    return [boefje for boefje in get_katalogus(organization.code).get_enabled_boefjes() if ooi_class in boefje.consumes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ follow_imports = "skip"
 exclude = [".git", "__pycache__", "old", "build", "dist", "venv"]
 paths = ["./"]
 min_confidence = 90
+ignore_names = ["mock_*"]
 
 [tool.pylint.format]
 max-line-length = 120

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,6 +31,7 @@ django-password-validators==1.7.0
 django-csp==3.7
 djangorestframework==3.14.0
 django-tagulous==1.3.3
+drf-standardized-errors==0.12.4
 
 # temp fix to pass build, remove later when https://github.com/xhtml2pdf/xhtml2pdf/issues/589 is solved
 reportlab==3.6.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ django-csp==3.7
 uwsgi==2.0.21
 djangorestframework==3.14.0
 django-tagulous==1.3.3
+drf-standardized-errors==0.12.4
 
 # temp fix to pass build, remove later when https://github.com/xhtml2pdf/xhtml2pdf/issues/589 is solved
 reportlab==3.6.12

--- a/rocky/admin.py
+++ b/rocky/admin.py
@@ -1,0 +1,13 @@
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+
+from rocky.exceptions import RockyError
+
+
+class AdminErrorMessageMixin:
+    def add_view(self, request, *args, **kwargs):
+        try:
+            return super().add_view(request, *args, **kwargs)
+        except RockyError as e:
+            self.message_user(request, str(e), level=messages.ERROR)
+            return HttpResponseRedirect(request.get_full_path())

--- a/rocky/exceptions.py
+++ b/rocky/exceptions.py
@@ -1,0 +1,2 @@
+class RockyError(Exception):
+    pass

--- a/rocky/settings.py
+++ b/rocky/settings.py
@@ -102,6 +102,7 @@ INSTALLED_APPS = [
     "django_password_validators.password_history",
     "rest_framework",
     "tagulous",
+    "drf_standardized_errors",
 ]
 
 MIDDLEWARE = [
@@ -340,6 +341,7 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAdminUser",
     ],
     "DEFAULT_RENDERER_CLASSES": DEFAULT_RENDERER_CLASSES,
+    "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler",
 }
 
 

--- a/rocky/views/ooi_detail.py
+++ b/rocky/views/ooi_detail.py
@@ -6,7 +6,8 @@ from django.http import Http404
 from django.shortcuts import redirect
 from octopoes.models import OOI
 from requests.exceptions import RequestException
-from katalogus.client import get_enabled_boefjes_for_ooi_class, get_katalogus
+from katalogus.client import get_katalogus
+from katalogus.utils import get_enabled_boefjes_for_ooi_class
 from rocky.views.mixins import OrganizationIndemnificationMixin
 from rocky.views.ooi_detail_related_object import OOIRelatedObjectAddView
 from rocky.views.ooi_view import BaseOOIDetailView

--- a/rocky/views/organization_member_list.py
+++ b/rocky/views/organization_member_list.py
@@ -8,7 +8,8 @@ from requests.exceptions import RequestException
 from django_otp.decorators import otp_required
 from two_factor.views.utils import class_view_decorator
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from tools.models import SCAN_LEVEL, Organization, OrganizationMember
+from tools.enums import SCAN_LEVEL
+from tools.models import Organization, OrganizationMember
 from tools.view_helpers import OrganizationMemberBreadcrumbsMixin
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from tools.models import Organization
@@ -5,7 +7,10 @@ from tools.models import Organization
 
 @pytest.fixture
 def organization():
-    organization = Organization.objects.create(name="Test Organization", code="test")
+    with patch("katalogus.client.KATalogusClientV1.create_organization"), patch(
+        "octopoes.connector.octopoes.OctopoesAPIConnector.create_node"
+    ):
+        organization = Organization.objects.create(name="Test Organization", code="test")
     return organization
 
 
@@ -14,3 +19,13 @@ def user(django_user_model):
     user = django_user_model.objects.create_user(email="admin@openkat.nl", password="TestTest123!!")
     user.is_verified = lambda: True
     return user
+
+
+@pytest.fixture
+def mock_katalogus(mocker):
+    mocker.patch("tools.models.get_katalogus")
+
+
+@pytest.fixture
+def mock_octopoes(mocker):
+    mocker.patch("tools.models.OctopoesAPIConnector")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from admin_auto_tests.test_model import ModelAdminTestCase
 from model_mommy import mommy, random_gen
 
@@ -10,3 +12,14 @@ mommy.generators.add("tools.fields.LowerCaseSlugField", random_gen.gen_slug)
 
 class OrganizationAdminTestCase(ModelAdminTestCase):
     model = Organization
+
+    def setUp(self):
+        super().setUp()
+
+        katalogus_patcher = patch("tools.models.get_katalogus")
+        katalogus_patcher.start()
+        self.addCleanup(katalogus_patcher.stop)
+
+        octopoes_patcher = patch("tools.models.OctopoesAPIConnector")
+        octopoes_patcher.start()
+        self.addCleanup(octopoes_patcher.stop)

--- a/tests/test_api_organization.py
+++ b/tests/test_api_organization.py
@@ -71,7 +71,7 @@ class TestOrganizationViewSet(ViewSetTest):
         def test_it_returns_values(self, organizations, json):
             expected = express_organizations(organizations)
             actual = json
-            assert expected == actual
+            assert actual == expected
 
     class TestCreate(
         UsesPostMethod,
@@ -88,7 +88,7 @@ class TestOrganizationViewSet(ViewSetTest):
         def test_it_creates_new_organization(self, initial_ids, json):
             expected = initial_ids | {json["id"]}
             actual = set(Organization.objects.values_list("id", flat=True))
-            assert expected == actual
+            assert actual == expected
 
         def test_it_sets_expected_attrs(self, data, json):
             organization = Organization.objects.get(pk=json["id"])
@@ -101,7 +101,7 @@ class TestOrganizationViewSet(ViewSetTest):
 
             expected = express_organization(organization)
             actual = json
-            assert expected == actual
+            assert actual == expected
 
     class TestCreateKatalogusError(
         UsesPostMethod,
@@ -126,7 +126,7 @@ class TestOrganizationViewSet(ViewSetTest):
                     }
                 ],
             }
-            assert expected == json
+            assert json == expected
 
     class TestCreateOctopoesError(
         UsesPostMethod,
@@ -153,7 +153,7 @@ class TestOrganizationViewSet(ViewSetTest):
                     }
                 ],
             }
-            assert expected == json
+            assert json == expected
 
     class TestRetrieve(
         UsesGetMethod,
@@ -163,7 +163,7 @@ class TestOrganizationViewSet(ViewSetTest):
         def test_it_returns_organization(self, organization, json):
             expected = express_organization(organization)
             actual = json
-            assert expected == actual
+            assert actual == expected
 
     class TestUpdate(
         UsesPatchMethod,
@@ -197,7 +197,7 @@ class TestOrganizationViewSet(ViewSetTest):
 
             expected = express_organization(organization)
             actual = json
-            assert expected == actual
+            assert actual == expected
 
     class TestDestroy(
         UsesDeleteMethod,
@@ -212,7 +212,7 @@ class TestOrganizationViewSet(ViewSetTest):
         def test_it_deletes_organization(self, initial_ids, organization):
             expected = initial_ids - {organization.id}
             actual = set(Organization.objects.values_list("id", flat=True))
-            assert expected == actual
+            assert actual == expected
 
     class TestDestroyKatalogusError(
         UsesDeleteMethod,
@@ -235,7 +235,7 @@ class TestOrganizationViewSet(ViewSetTest):
                     }
                 ],
             }
-            assert expected == json
+            assert json == expected
 
     class TestDestroyOctopoesError(
         UsesDeleteMethod,
@@ -260,4 +260,4 @@ class TestOrganizationViewSet(ViewSetTest):
                     }
                 ],
             }
-            assert expected == json
+            assert json == expected

--- a/tests/test_api_organization.py
+++ b/tests/test_api_organization.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict
+from unittest.mock import patch
 
 import pytest
 from pytest_assert_utils import assert_model_attrs
 from pytest_common_subject import precondition_fixture
 from pytest_drf import (
-    AsUser,
     Returns200,
     Returns201,
     Returns204,
+    Returns500,
     UsesGetMethod,
     UsesDeleteMethod,
     UsesDetailEndpoint,
@@ -18,6 +19,7 @@ from pytest_drf import (
 )
 from pytest_drf.util import pluralized, url_for
 from pytest_lambda import lambda_fixture, static_fixture
+from requests import HTTPError
 
 from tools.models import Organization
 
@@ -37,17 +39,29 @@ def express_organization(organization: Organization) -> Dict[str, Any]:
 express_organizations = pluralized(express_organization)
 
 
-class TestOrganizationViewSet(ViewSetTest, AsUser("admin_user")):
+class TestOrganizationViewSet(ViewSetTest):
+    @pytest.fixture
+    def organizations(self):
+        with patch("katalogus.client.KATalogusClientV1.create_organization"), patch(
+            "octopoes.connector.octopoes.OctopoesAPIConnector.create_node"
+        ):
+            return [
+                Organization.objects.create(name="Test Organization 1", code="test1", tags=["tag1", "tag2"]),
+                Organization.objects.create(name="Test Organization 2", code="test2"),
+            ]
+
+    organization = lambda_fixture(lambda organizations: organizations[0])
+
     list_url = lambda_fixture(lambda: url_for("organization-list"))
     detail_url = lambda_fixture(lambda organization: url_for("organization-detail", organization.pk))
 
-    organizations = lambda_fixture(
-        lambda: [
-            Organization.objects.create(name="Test Organistion", code="test", tags=["tag1", "tag2"]),
-            Organization.objects.create(name="Test Organization 2", code="test2"),
-        ],
-    )
-    organization = lambda_fixture(lambda organizations: organizations[0])
+    @pytest.fixture
+    def client(self, create_drf_client, admin_user):
+        client = create_drf_client(admin_user)
+        # We need to set this so that the test client doesn't throw an
+        # exception, but will return error in the API we can test
+        client.raise_request_exception = False
+        return client
 
     class TestList(
         UsesGetMethod,
@@ -67,7 +81,8 @@ class TestOrganizationViewSet(ViewSetTest, AsUser("admin_user")):
         data = static_fixture({"name": "Test Org 3", "code": "test3", "tags": ["tag2", "tag3"]})
 
         initial_ids = precondition_fixture(
-            lambda organizations: set(Organization.objects.values_list("id", flat=True)), async_=False
+            lambda mock_katalogus, mock_octopoes, organizations: set(Organization.objects.values_list("id", flat=True)),
+            async_=False,
         )
 
         def test_it_creates_new_organization(self, initial_ids, json):
@@ -88,6 +103,58 @@ class TestOrganizationViewSet(ViewSetTest, AsUser("admin_user")):
             actual = json
             assert expected == actual
 
+    class TestCreateKatalogusError(
+        UsesPostMethod,
+        UsesListEndpoint,
+        Returns500,
+    ):
+        data = static_fixture({"name": "Test Org 3", "code": "test3", "tags": ["tag2", "tag3"]})
+
+        @pytest.fixture(autouse=True)
+        def mock_services(self, mocker):
+            mocker.patch("katalogus.client.KATalogusClientV1.create_organization", side_effect=HTTPError("Test error"))
+            mocker.patch("octopoes.connector.octopoes.OctopoesAPIConnector.create_node")
+
+        def test_it_returns_error(self, json):
+            expected = {
+                "type": "server_error",
+                "errors": [
+                    {
+                        "code": "error",
+                        "detail": "Katalogus returned error creating organization: Test error",
+                        "attr": None,
+                    }
+                ],
+            }
+            assert expected == json
+
+    class TestCreateOctopoesError(
+        UsesPostMethod,
+        UsesListEndpoint,
+        Returns500,
+    ):
+        data = static_fixture({"name": "Test Org 3", "code": "test3", "tags": ["tag2", "tag3"]})
+
+        @pytest.fixture(autouse=True)
+        def mock_services(self, mocker):
+            mocker.patch("katalogus.client.KATalogusClientV1.create_organization")
+            mocker.patch(
+                "octopoes.connector.octopoes.OctopoesAPIConnector.create_node", side_effect=HTTPError("Test error")
+            )
+
+        def test_it_returns_error(self, json):
+            expected = {
+                "type": "server_error",
+                "errors": [
+                    {
+                        "code": "error",
+                        "detail": "Octopoes returned error creating organization: Test error",
+                        "attr": None,
+                    }
+                ],
+            }
+            assert expected == json
+
     class TestRetrieve(
         UsesGetMethod,
         UsesDetailEndpoint,
@@ -105,7 +172,7 @@ class TestOrganizationViewSet(ViewSetTest, AsUser("admin_user")):
     ):
         data = static_fixture(
             {
-                "name": "Changed Orgazisation",
+                "name": "Changed Organization",
                 "code": "test4",
                 "tags": ["tag3", "tag4"],
             }
@@ -113,8 +180,8 @@ class TestOrganizationViewSet(ViewSetTest, AsUser("admin_user")):
 
         # Code is read only so shouldn't change
         expected_data = {
-            "name": "Changed Orgazisation",
-            "code": "test",
+            "name": "Changed Organization",
+            "code": "test1",
         }
 
         def test_it_sets_expected_attrs(self, organization):
@@ -138,10 +205,59 @@ class TestOrganizationViewSet(ViewSetTest, AsUser("admin_user")):
         Returns204,
     ):
         initial_ids = precondition_fixture(
-            lambda organizations: set(Organization.objects.values_list("id", flat=True)), async_=False
+            lambda mock_katalogus, mock_octopoes, organizations: set(Organization.objects.values_list("id", flat=True)),
+            async_=False,
         )
 
         def test_it_deletes_organization(self, initial_ids, organization):
             expected = initial_ids - {organization.id}
             actual = set(Organization.objects.values_list("id", flat=True))
             assert expected == actual
+
+    class TestDestroyKatalogusError(
+        UsesDeleteMethod,
+        UsesDetailEndpoint,
+        Returns500,
+    ):
+        @pytest.fixture(autouse=True)
+        def mock_services(self, mocker):
+            mocker.patch("katalogus.client.KATalogusClientV1.delete_organization", side_effect=HTTPError("Test error"))
+            mocker.patch("octopoes.connector.octopoes.OctopoesAPIConnector.delete_node")
+
+        def test_it_returns_error(self, json):
+            expected = {
+                "type": "server_error",
+                "errors": [
+                    {
+                        "code": "error",
+                        "detail": "Katalogus returned error deleting organization: Test error",
+                        "attr": None,
+                    }
+                ],
+            }
+            assert expected == json
+
+    class TestDestroyOctopoesError(
+        UsesDeleteMethod,
+        UsesDetailEndpoint,
+        Returns500,
+    ):
+        @pytest.fixture(autouse=True)
+        def mock_services(self, mocker):
+            mocker.patch("katalogus.client.KATalogusClientV1.delete_organization")
+            mocker.patch(
+                "octopoes.connector.octopoes.OctopoesAPIConnector.delete_node", side_effect=HTTPError("Test error")
+            )
+
+        def test_it_returns_error(self, json):
+            expected = {
+                "type": "server_error",
+                "errors": [
+                    {
+                        "code": "error",
+                        "detail": "Octopoes returned error deleting organization: Test error",
+                        "attr": None,
+                    }
+                ],
+            }
+            assert expected == json

--- a/tools/admin.py
+++ b/tools/admin.py
@@ -7,6 +7,8 @@ from django.forms import widgets
 
 import tagulous.admin
 
+from rocky.admin import AdminErrorMessageMixin
+
 from tools.models import (
     Organization,
     OrganizationMember,
@@ -49,7 +51,7 @@ class OOIInformationAdmin(admin.ModelAdmin):
         return self.readonly_fields
 
 
-class OrganizationAdmin(admin.ModelAdmin):
+class OrganizationAdmin(AdminErrorMessageMixin, admin.ModelAdmin):
     list_display = ["name", "code", "tags"]
 
     def has_delete_permission(self, request, obj=None):

--- a/tools/enums.py
+++ b/tools/enums.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class SCAN_LEVEL(models.IntegerChoices):
+    L0 = 0, "L0"
+    L1 = 1, "L1"
+    L2 = 2, "L2"
+    L3 = 3, "L3"
+    L4 = 4, "L4"

--- a/tools/forms/settings.py
+++ b/tools/forms/settings.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple, Any
 from django.utils.translation import gettext_lazy as _
-from tools.models import SCAN_LEVEL
+from tools.enums import SCAN_LEVEL
 
 Choice = Tuple[Any, str]
 Choices = List[Choice]

--- a/tools/management/commands/setup_dev_account.py
+++ b/tools/management/commands/setup_dev_account.py
@@ -6,8 +6,8 @@ from django.core.management import BaseCommand
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ObjectDoesNotExist
 
+from tools.enums import SCAN_LEVEL
 from tools.models import (
-    SCAN_LEVEL,
     Organization,
     OrganizationMember,
     GROUP_CLIENT,

--- a/tools/ooi_form.py
+++ b/tools/ooi_form.py
@@ -11,7 +11,7 @@ from pydantic import AnyUrl
 from pydantic.fields import ModelField, SHAPE_LIST
 
 from tools.forms import BaseRockyForm, CheckboxGroup
-from tools.models import SCAN_LEVEL
+from tools.enums import SCAN_LEVEL
 
 
 class OOIForm(BaseRockyForm):

--- a/whitelist.py
+++ b/whitelist.py
@@ -1,0 +1,1 @@
+sender  # unused variable (tools/models.py:90)


### PR DESCRIPTION
Add automatic creation and deletion of nodes octopoes/xtdb and organization in katalogus.

A few things are moved around to prevent circular imports between katalogus/client.py and tools/models.py.

The error messages in the API are formatted using drf-standardized-errors.
