### PR TITLE
Ignore minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+- package-ecosystem: "pip" # See documentation for possible values
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "*"
+    update-types: ["version-update:semver-minor"]


### PR DESCRIPTION
## Changes
Update Dependabot config to ignore minor version updates.

## Good to know
- Does this PR introduce or depend on API-incompatible changes? If yes: what do other users/developers need to do or confirm before merging?
  - No
- Does this PR depend on a specific version of a library?
  - No
- Does this PR require config, setup, or `.env` changes?
  - No
