### PR TITLE
Fix nav and breadcrumbs for objects, findings and tasks

### DIFF
--- a/rocky/templates/header.html
+++ b/rocky/templates/header.html
@@ -36,11 +36,11 @@
           </li>
           <li>
             <a href="{% url 'finding_list' organization.code %}"
-               {% if 'finding' in request.path|urlencode %} aria-current="page"{% endif %}>{% translate 'Findings' %}</a>
+               {% if 'finding' in request.path|urlencode or 'Finding' in request.get_full_path|urlencode %} aria-current="page"{% endif %}>{% translate 'Findings' %}</a>
           </li>
           <li>
             <a href="{% url 'ooi_list' organization.code %}"
-               {% if 'objects' in request.path|urlencode %} aria-current="page"{% endif %}>{% translate 'Objects' %}</a>
+            {% if 'objects' in request.path|urlencode and not 'Finding' in request.get_full_path|urlencode %} aria-current="page"{% endif %}>{% translate 'Objects' %}</a>
           </li>
           <li>
             <a href="{% url 'task_list' organization.code %}"

--- a/rocky/views/ooi_detail.py
+++ b/rocky/views/ooi_detail.py
@@ -6,8 +6,6 @@ from django.contrib import messages
 from django.core.paginator import Paginator, Page
 from django.http import Http404
 from django.shortcuts import redirect
-from django.urls import reverse
-from django.utils.translation import gettext_lazy as _
 from requests.exceptions import RequestException
 
 from katalogus.client import get_katalogus
@@ -22,7 +20,6 @@ from tools.forms.base import ObservedAtForm
 from tools.forms.ooi import PossibleBoefjesFilterForm
 from tools.models import Indemnification, OrganizationMember
 from tools.ooi_helpers import format_display
-from tools.view_helpers import get_ooi_url
 
 
 class PageActions(Enum):

--- a/rocky/views/ooi_detail.py
+++ b/rocky/views/ooi_detail.py
@@ -6,6 +6,8 @@ from django.contrib import messages
 from django.core.paginator import Paginator, Page
 from django.http import Http404
 from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from requests.exceptions import RequestException
 
 from katalogus.client import get_katalogus
@@ -13,12 +15,14 @@ from katalogus.utils import get_enabled_boefjes_for_ooi_class
 from katalogus.views.mixins import BoefjeMixin
 from octopoes.models import OOI
 from rocky import scheduler
+from rocky.views.mixins import OOIBreadcrumbsMixin
 from rocky.views.ooi_detail_related_object import OOIRelatedObjectAddView
 from rocky.views.ooi_view import BaseOOIDetailView
 from tools.forms.base import ObservedAtForm
 from tools.forms.ooi import PossibleBoefjesFilterForm
 from tools.models import Indemnification, OrganizationMember
 from tools.ooi_helpers import format_display
+from tools.view_helpers import get_ooi_url
 
 
 class PageActions(Enum):
@@ -29,6 +33,7 @@ class OOIDetailView(
     BoefjeMixin,
     OOIRelatedObjectAddView,
     BaseOOIDetailView,
+    OOIBreadcrumbsMixin,
 ):
     template_name = "oois/ooi_detail.html"
     connector_form_class = ObservedAtForm
@@ -170,7 +175,6 @@ class OOIDetailView(
         context["severity_summary_totals"] = self.get_findings_severity_totals()
         context["possible_boefjes_filter_form"] = filter_form
         context["organization_indemnification"] = self.get_organization_indemnification()
-
         context["scan_history"] = self.get_scan_history()
         context["scan_history_form_fields"] = [
             "scan_history_from",

--- a/rocky/views/ooi_list.py
+++ b/rocky/views/ooi_list.py
@@ -9,6 +9,7 @@ from django.http import HttpResponse, Http404, HttpRequest
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django_otp.decorators import otp_required
+from django.urls import reverse
 from requests import RequestException
 from two_factor.views.utils import class_view_decorator
 
@@ -50,6 +51,10 @@ class OOIListView(BaseOOIListView):
         context["member"] = self.organization_member
         context["scan_levels"] = [alias for level, alias in SCAN_LEVEL.choices]
         context["organization_indemnification"] = self.get_organization_indemnification
+        context["breadcrumbs"] = [
+            {"url": reverse("ooi_list", kwargs={"organization_code": self.organization.code}), "text": _("Objects")},
+        ]
+
 
         return context
 

--- a/rocky/views/ooi_list.py
+++ b/rocky/views/ooi_list.py
@@ -55,7 +55,6 @@ class OOIListView(BaseOOIListView):
             {"url": reverse("ooi_list", kwargs={"organization_code": self.organization.code}), "text": _("Objects")},
         ]
 
-
         return context
 
     def get(self, request: HttpRequest, status=200, *args, **kwargs) -> HttpResponse:

--- a/rocky/views/tasks.py
+++ b/rocky/views/tasks.py
@@ -78,7 +78,6 @@ class TaskListView(OrganizationView, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["breadcrumbs"] = [
-            {"url": reverse("ooi_list", kwargs={"organization_code": self.organization.code}), "text": _("Objects")},
             {"url": reverse("task_list", kwargs={"organization_code": self.organization.code}), "text": _("Tasks")},
         ]
         return context


### PR DESCRIPTION
Fixes all occurrences that were reported in https://github.com/minvws/nl-kat-rocky/issues/110

Tasks page had previously "objects > tasks" as breadcrumbs. Currently:
![Screenshot 2023-01-25 at 15 03 03](https://user-images.githubusercontent.com/16188579/214583917-12ea45c6-a213-4240-9b9e-7975174b869f.png)

Objects page had previously "findings > object name" as breadcrumbs. Currently:
![Screenshot 2023-01-25 at 15 03 11](https://user-images.githubusercontent.com/16188579/214583920-18fe13bf-d76e-4738-81f0-bfe065500347.png)

Findings page had previously "findings" and "objects" as highlighted menu items. Currently:
![Screenshot 2023-01-25 at 15 03 20](https://user-images.githubusercontent.com/16188579/214583922-996fa8d8-0991-47b4-bf3c-54823d1c9cc6.png)
